### PR TITLE
Consolidate Docker setup in README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,22 @@ python parse_logs.py &
 python zlog_queue.py &
 ```
 
+## Docker Setup
+
+To build and run the Docker container for this project, follow these steps:
+
+1. **Build the Docker image:**
+   ```sh
+   docker build -t zlog_parsing .
+   ```
+
+2. **Run the Docker container:**
+   ```sh
+   docker run -d zlog_parsing
+   ```
+
+This will start the log parsing and queue management processes inside the Docker container.
+
 ## Documentation
 
 Comprehensive documentation for the project is available in the `docs` directory. The documentation includes detailed instructions for setup, usage, and descriptions of each module and function.


### PR DESCRIPTION
Add Docker setup instructions to `readme.md`.

* Add a new section "Docker Setup" to `readme.md`.
* Include instructions to build the Docker image with `docker build -t zlog_parsing .`.
* Include instructions to run the Docker container with `docker run -d zlog_parsing`.
* Mention that this will start the log parsing and queue management processes inside the Docker container.

