### PR TITLE
Optimize log parsing loop

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -12,10 +12,10 @@ Parses a log entry and inserts it into the `push` and `event_log` tables if cert
 Fetches all rows from the `pm_table`.
 
 ### pm_update
-Updates the `pm_table` with a new log entry if certain conditions are met.
+Updates the `pm_table` with a new log entry if certain conditions are met. Uses an in-memory cache to avoid duplicate lookups.
 
 ### main
-Main function that sets up logging, fetches logs from the `logs_queue`, processes them, and updates the `pm_table`.
+Main function that sets up logging, fetches logs from the `logs_queue` in batches, processes them, and updates the `pm_table`.
 
 ## psconnect.py
 
@@ -36,6 +36,9 @@ Selects rows from a specified table based on conditions.
 
 ### delete_from
 Deletes rows from a specified table based on conditions.
+
+### delete_many
+Deletes multiple rows from a specified table based on a list of IDs.
 
 ## zlog_queue.py
 

--- a/parse_logs.py
+++ b/parse_logs.py
@@ -1,7 +1,14 @@
 #!/home/michael/.pyenv/shims/python
 # parse_logs.py
 
-from psconnect import get_db_connection, insert_into, select_from, delete_from, Connection, Row
+from psconnect import (
+    get_db_connection,
+    insert_into,
+    select_from,
+    delete_many,
+    Connection,
+    Row,
+)
 from zlog_queue import get_last_processed_id
 import time
 
@@ -30,7 +37,8 @@ def setup_logging() -> None:
     logger.addHandler(debug_handler)
 
 
-conn = get_db_connection()
+conn: Connection | None = None
+pm_cache: set[tuple[str, str]] = set()
 
 
 def parse_log(log: Row) -> None:
@@ -79,11 +87,13 @@ def pm_update(log: Row) -> None:
     """
     Updates the 'pm_table' with a log entry if it meets certain criteria.
     """
-    pm_table = fetch_pm_table(conn)
-    if log['window'] == log['nick'] and log['window'][0] != '#':
-        if not any(row['window'] == log['window'] and row['nick'] == log['nick'] for row in pm_table):
+    global pm_cache
+    if log['window'] == log['nick'] and not log['window'].startswith('#'):
+        key = (log['window'], log['nick'])
+        if key not in pm_cache:
             try:
                 insert_into(conn, log, 'pm_table')
+                pm_cache.add(key)
             except Exception as e:
                 logging.error("Failed to insert log %s into pm_table: %s", log["id"], e)
 
@@ -92,25 +102,29 @@ def main() -> None:
     """
     Main function that sets up logging, processes logs from the 'logs_queue' table, and updates the 'pm_table'.
     """
+    global conn, pm_cache
     setup_logging()
     try:
         conn = get_db_connection()
+        pm_cache = {(row['window'], row['nick']) for row in fetch_pm_table(conn)}
         last_processed_id = get_last_processed_id(conn) or 28000000
+        batch_size = 100
         while True:
-            logs = select_from(conn, "logs_queue", last_processed_id, desc=False)
+            logs = select_from(conn, "logs_queue", last_processed_id, desc=False, limit=batch_size)
             if not logs:
-                time.sleep(10)  # Sleep for some time before checking for new logs
+                time.sleep(1)
                 continue
+            ids_to_delete = []
             for log in logs:
-
                 parse_log(log)
                 pm_update(log)
-                try:
-                    delete_from(conn, 'logs_queue', {"id": log["id"]})
-                except Exception as e:
-                    logging.error("Failed to delete log %s from logs_queue: %s", log["id"], e)
-                print(f"Processed log {log['id']}")
+                ids_to_delete.append(log["id"])
                 last_processed_id = log["id"]
+            try:
+                delete_many(conn, 'logs_queue', ids_to_delete)
+            except Exception as e:
+                logging.error("Failed to delete logs from logs_queue: %s", e)
+            print(f"Processed up to log {last_processed_id}")
     except Exception as e:
         logging.error("An error occurred: %s", e)
         print(f"An error occurred: {e}")
@@ -118,3 +132,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+

--- a/psconnect.py
+++ b/psconnect.py
@@ -189,15 +189,42 @@ def replace_into(conn: pymysql.Connection, row: Row, table: str) -> None:
         logging.error(f"Error replacing into {table}: {e}")
 
 
-def select_from(conn: pymysql.Connection, table: str, base: int = 28000000, desc: bool = False) -> Optional[list[dict]]:
-    """
-    Selects rows from a specified table in the database where the id is greater than a base value.
-    Returns a list of dictionaries representing the selected rows.
+def select_from(
+    conn: pymysql.Connection,
+    table: str,
+    base: int = 28000000,
+    desc: bool = False,
+    limit: Optional[int] = None,
+) -> Optional[list[dict]]:
+    """Select rows from ``table`` where ``id`` is greater than ``base``.
+
+    Parameters
+    ----------
+    conn : Connection
+        Database connection.
+    table : str
+        Table name to query.
+    base : int, optional
+        Minimum ``id`` to select from, by default ``28000000``.
+    desc : bool, optional
+        Order results descending when ``True``.
+    limit : Optional[int], optional
+        Maximum number of rows to return. ``None`` for no limit.
+
+    Returns
+    -------
+    Optional[list[dict]]
+        List of rows returned from the query or ``None`` on error.
     """
     try:
         # Execute the select statement
         with conn.cursor() as cursor:
-            cursor.execute(f"SELECT * FROM {table} WHERE id > {base} ORDER BY id {'DESC' if desc else 'ASC'}")
+            limit_clause = f" LIMIT {limit}" if limit else ""
+            sql = (
+                f"SELECT * FROM {table} WHERE id > {base} "
+                f"ORDER BY id {'DESC' if desc else 'ASC'}{limit_clause}"
+            )
+            cursor.execute(sql)
             return cursor.fetchall()
     except pymysql.MySQLError as e:
         logging.error(f"Error selecting from {table}: {e}")
@@ -232,3 +259,21 @@ def delete_from(conn: pymysql.Connection, table: str, conditions: dict) -> None:
         # Rollback the transaction in case of an error
         conn.rollback()
         logging.error(f"Error deleting from {table}: {e}")
+        raise e
+
+
+def delete_many(conn: pymysql.Connection, table: str, ids: list[int]) -> None:
+    """Delete multiple rows from ``table`` by ``id``."""
+    if not ids:
+        return
+    placeholders = ",".join(["%s"] * len(ids))
+    sql = f"DELETE FROM `{table}` WHERE id IN ({placeholders})"
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute(sql, ids)
+            conn.commit()
+    except pymysql.MySQLError as e:
+        conn.rollback()
+        logging.error(f"Error deleting many from {table}: {e}")
+        raise e
+


### PR DESCRIPTION
## Summary
- speed up parsing loop by batching DB calls
- cache `pm_table` lookups to avoid repetitive queries
- add `delete_many` and update `select_from` with limit
- document new utility functions and loop improvements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cbda1622c83248df3b7ebffd1cb1a