### PR TITLE
Document rule list in DB

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -67,3 +67,7 @@ Determines whether a log entry matches a given rule.
 
 ### fetch_rules
 Retrieves a user's hotword rules from the database.
+
+### Rule JSON Structure
+Rules for each user are stored in the `users.hotwords` JSON column as a list of rule objects.
+See [rules.md](rules.md) for a full description of the filtering rule format used by `parse_logs.py`.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,0 +1,61 @@
+# Filtering Rules
+
+This document describes the JSON structure used to define filtering rules for
+log entries. Each user stores these rules in the `users.hotwords` column. The
+column is defined as a JSON field and **must** contain a JSON array of rule
+objects, even when a user has only a single rule.
+
+```
+CREATE TABLE `users` (
+  `nickname` VARCHAR(64) NOT NULL,
+  `telegram_chat_id` BIGINT DEFAULT NULL,
+  `hotwords` JSON DEFAULT NULL,
+  PRIMARY KEY (`nickname`)
+);
+```
+
+Example with a single rule:
+
+```json
+[
+  {"type": "pm"}
+]
+```
+
+## Rule Object
+
+A rule is a JSON object with the following common fields:
+
+- `type` – either `substring` or `pm`.
+- `case_sensitive` – optional boolean, defaults to `false` when omitted.
+- `only_if` – optional object of additional conditions that **must** match.
+- `not_if` – optional object of conditions that suppress the rule when all match.
+
+### Substring Rules
+
+```json
+{
+  "type": "substring",
+  "match": "hello",
+  "case_sensitive": false,
+  "only_if": {"window": "#support"},
+  "not_if": {"nick": "bot"}
+}
+```
+
+- `match` – substring to look for in the log `message`.
+- `only_if` may contain field/value pairs or `contains` to require a substring in the message.
+- `not_if` works the same way but disables the rule when satisfied.
+
+### PM Rules
+
+```json
+{"type": "pm"}
+```
+
+A PM rule triggers when a log entry is a private message (`window` equals `nick` and is not a channel). No other fields are required.
+
+## Evaluation Logic
+
+`parse_logs.py` obtains the rule list for each user and evaluates them using `rules.match_rule`. Rules are processed in the order they appear, and the first match causes the log entry to be queued for that user.
+

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -40,3 +40,22 @@ Install dependencies listed in `requirements.txt` using `pip install -r requirem
 - `parse_logs.py` reads logs from `logs_queue`, applies hotword rules and writes matching entries to `push` and `event_log`.
 - `zlog_queue.py` monitors the `logs` table and enqueues new log lines for processing.
 - `rules.py` contains helper functions for validating and evaluating the hotword rules stored for each user.
+
+## Filtering Rules
+
+Users define filtering rules as JSON objects stored in the `users.hotwords` column.
+The value is a JSON **array** of rule objects even when only a single rule is defined.
+Each rule determines whether a log line should be delivered to that user. See
+[docs/rules.md](rules.md) for the full schema. A simple example:
+
+```json
+[
+  {
+    "type": "substring",
+    "match": "error",
+    "only_if": {"window": "#general"}
+  }
+]
+```
+
+The parser evaluates these rules for every log line and queues matches into the `push` table.

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,12 @@ A simple container definition is provided in `main.dockerfile`. Build and run wi
 docker build -f main.dockerfile -t zlog_parsing .
 docker run -d zlog_parsing
 ```
+## Filtering Rules
+
+Each user record contains a `hotwords` JSON column storing a **list** of rule objects.
+Rules decide which log lines are queued for that user. Even a single rule must be
+wrapped in a JSON array. See [docs/rules.md](docs/rules.md) for details.
+
 
 ## Documentation
 
@@ -44,6 +50,7 @@ Additional documentation and module descriptions can be found in the `docs` dire
 - [Setup Instructions](docs/setup.md)
 - [Usage Instructions](docs/usage.md)
 - [Modules Documentation](docs/modules.md)
+- [Filtering Rules](docs/rules.md)
 
 ## License
 


### PR DESCRIPTION
## Summary
- explain that rules live in users.hotwords JSON array
- show an example array in usage guide and rules docs
- mention hotwords storage in modules doc and README

## Testing
- `black .`
- `flake8 .` *(fails: command not found)*
- `python parse_logs.py --dry-run` *(fails: ModuleNotFoundError: No module named 'pymysql')*
- `python -m rules validate` *(fails: ModuleNotFoundError: No module named 'pymysql')*


------
https://chatgpt.com/codex/tasks/task_e_686fccc1e32883248c016230302013fd